### PR TITLE
Change shortid characters

### DIFF
--- a/source/api/services/package/lib/content-package.js
+++ b/source/api/services/package/lib/content-package.js
@@ -119,7 +119,7 @@ let contentPackage = (function() {
                         }
                     }
                 }
-
+                shortid.characters('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$@');
                 let _package = _body.package;
                 let _newpackage = {
                     package_id: shortid.generate(),


### PR DESCRIPTION
Package ID's containing a hyphen cause issues when deleting, replaced them with $ and @ instead.